### PR TITLE
Mixin simplification/V-model capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+/docs/.vuepress/dist
 
 /tests/e2e/videos/
 /tests/e2e/screenshots/

--- a/docs/.vuepress/components/ExampleVModel.vue
+++ b/docs/.vuepress/components/ExampleVModel.vue
@@ -11,17 +11,22 @@
 </template>
 
 <script>
+import OutputDisplay from './OutputDisplay'
+import FormText from '../../../src/form-elements/FormText'
+import FormSelect from '../../../src/form-elements/FormSelect'
+import FormCheckbox from '../../../src/form-elements/FormCheckbox'
+
 const SCHEMA = {
   firstName: {
-    component: 'FormText',
+    component: FormText,
     label: 'First Name',
   },
   lastName: {
-    component: 'FormText',
+    component: FormText,
     label: 'Last Name',
   },
   email: {
-    component: 'FormText',
+    component: FormText,
     label: 'Your email',
     required: true,
     config: {
@@ -29,7 +34,7 @@ const SCHEMA = {
     }
   },
   favoriteThingAboutVue: {
-    component: 'FormSelect',
+    component: FormSelect,
     label: 'Favorite thing about Vue',
     required: true,
     options: [
@@ -39,12 +44,11 @@ const SCHEMA = {
     ]
   },
   isVueFan: {
-    component: 'FormCheckbox',
+    component: FormCheckbox,
     label: 'Are you a Vue fan?'
   }
 }
 
-import OutputDisplay from './OutputDisplay'
 export default {
   components: { OutputDisplay },
   data () {
@@ -58,7 +62,7 @@ export default {
         ? {
             ...SCHEMA,
             feedback: {
-              component: 'FormText',
+              component: FormText,
               label: 'Gimme some feedback'
             }
           }

--- a/docs/.vuepress/components/ExampleVModel.vue
+++ b/docs/.vuepress/components/ExampleVModel.vue
@@ -1,0 +1,88 @@
+<template>
+  <div>
+    <SchemaForm
+    :schema="schema"
+    v-model="userData"
+  />
+
+    <div class="output">
+      vModel Output:
+      <ul>
+        <li
+          v-for="(value, prop) in userData"
+          :key="prop"
+        >
+          {{ prop }}: {{ value }}
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+const SCHEMA = {
+  firstName: {
+    component: 'FormText',
+    label: 'First Name',
+  },
+  lastName: {
+    component: 'FormText',
+    label: 'Last Name',
+  },
+  email: {
+    component: 'FormText',
+    label: 'Your email',
+    required: true,
+    config: {
+      type: 'email'
+    }
+  },
+  isVueFan: {
+    component: 'FormCheckbox',
+    label: 'Are you a Vue fan?'
+  }
+}
+
+export default {
+  data () {
+    return {
+      userData: {}
+    }
+  },
+  computed: {
+    schema () {
+      return this.userData.isVueFan
+        ? {
+            ...SCHEMA,
+            feedback: {
+              component: 'FormText',
+              label: 'Gimme some feedback'
+            }
+          }
+        : SCHEMA
+    }
+  },
+  methods: {
+    mergeChanges (changes) {
+      this.userData = {
+        ...this.userData,
+        ...changes
+      }
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+.steps
+  max-width: 35rem
+  text-align: left
+  margin: 0 auto 4rem
+  line-height: 1.6
+
+.output
+  max-width: 35rem
+  margin: 0 auto 4rem
+  ul
+    list-style: none
+</style>

--- a/docs/.vuepress/components/ExampleVModel.vue
+++ b/docs/.vuepress/components/ExampleVModel.vue
@@ -1,21 +1,11 @@
 <template>
   <div>
     <SchemaForm
-    :schema="schema"
-    v-model="userData"
-  />
+      :schema="schema"
+      v-model="userData"
+    />
 
-    <div class="output">
-      vModel Output:
-      <ul>
-        <li
-          v-for="(value, prop) in userData"
-          :key="prop"
-        >
-          {{ prop }}: {{ value }}
-        </li>
-      </ul>
-    </div>
+    <OutputDisplay :data="userData" />
   </div>
 </template>
 
@@ -43,7 +33,9 @@ const SCHEMA = {
   }
 }
 
+import OutputDisplay from './OutputDisplay'
 export default {
+  components: { OutputDisplay },
   data () {
     return {
       userData: {}
@@ -79,10 +71,4 @@ export default {
   text-align: left
   margin: 0 auto 4rem
   line-height: 1.6
-
-.output
-  max-width: 35rem
-  margin: 0 auto 4rem
-  ul
-    list-style: none
 </style>

--- a/docs/.vuepress/components/ExampleVModel.vue
+++ b/docs/.vuepress/components/ExampleVModel.vue
@@ -5,6 +5,7 @@
       v-model="userData"
     />
 
+    <p>Form Output:</p>
     <OutputDisplay :data="userData" />
   </div>
 </template>
@@ -26,6 +27,16 @@ const SCHEMA = {
     config: {
       type: 'email'
     }
+  },
+  favoriteThingAboutVue: {
+    component: 'FormSelect',
+    label: 'Favorite thing about Vue',
+    required: true,
+    options: [
+      'Ease of use',
+      'Documentation',
+      'Community'
+    ]
   },
   isVueFan: {
     component: 'FormCheckbox',

--- a/docs/.vuepress/components/Formception.vue
+++ b/docs/.vuepress/components/Formception.vue
@@ -16,17 +16,23 @@
 </template>
 
 <script>
+import OutputDisplay from './OutputDisplay'
+import FormText from '../../../src/form-elements/FormText'
+import FormSelect from '../../../src/form-elements/FormSelect'
+import FormCheckbox from '../../../src/form-elements/FormCheckbox'
+import SchemaForm from '../../../src/SchemaForm'
+
 const SCHEMA = {
   firstName: {
-    component: 'FormText',
+    component: FormText,
     label: 'First Name',
   },
   lastName: {
-    component: 'FormText',
+    component: FormText,
     label: 'Last Name',
   },
   email: {
-    component: 'FormText',
+    component: FormText,
     label: 'Your email',
     required: true,
     config: {
@@ -34,7 +40,7 @@ const SCHEMA = {
     }
   },
   favoriteThingAboutVue: {
-    component: 'FormSelect',
+    component: FormSelect,
     label: 'Favorite thing about Vue',
     required: true,
     options: [
@@ -44,29 +50,29 @@ const SCHEMA = {
     ]
   },
   isVueFan: {
-    component: 'FormCheckbox',
+    component: FormCheckbox,
     label: 'Are you a Vue fan?'
   },
   work: {
-    component: 'SchemaForm',
+    component: SchemaForm,
     schema: {
       address: {
-        component: 'FormText',
+        component: FormText,
         label: 'Work address'
       },
       phone: {
-        component: 'FormText',
+        component: FormText,
         label: 'Work phone'
       },
       details: {
-        component: 'SchemaForm',
+        component: SchemaForm,
         schema: {
           position: {
-            component: 'FormText',
+            component: FormText,
             label: 'Work position'
           },
           employees: {
-            component: 'FormSelect',
+            component: FormSelect,
             label: 'Number of employees',
             options: [
               '1', '2', '3', '4+'
@@ -78,7 +84,6 @@ const SCHEMA = {
   }
 }
 
-import OutputDisplay from './OutputDisplay'
 export default {
   components: { OutputDisplay },
   data () {
@@ -92,7 +97,7 @@ export default {
         ? {
             ...SCHEMA,
             feedback: {
-              component: 'FormText',
+              component: FormText,
               label: 'Gimme some feedback'
             }
           }

--- a/docs/.vuepress/components/Formception.vue
+++ b/docs/.vuepress/components/Formception.vue
@@ -33,6 +33,16 @@ const SCHEMA = {
       type: 'email'
     }
   },
+  favoriteThingAboutVue: {
+    component: 'FormSelect',
+    label: 'Favorite thing about Vue',
+    required: true,
+    options: [
+      'Ease of use',
+      'Documentation',
+      'Community'
+    ]
+  },
   isVueFan: {
     component: 'FormCheckbox',
     label: 'Are you a Vue fan?'
@@ -54,6 +64,13 @@ const SCHEMA = {
           position: {
             component: 'FormText',
             label: 'Work position'
+          },
+          employees: {
+            component: 'FormSelect',
+            label: 'Number of employees',
+            options: [
+              '1', '2', '3', '4+'
+            ]
           }
         }
       }

--- a/docs/.vuepress/components/Formception.vue
+++ b/docs/.vuepress/components/Formception.vue
@@ -1,21 +1,17 @@
 <template>
   <div>
     <SchemaForm
-    :schema="schema"
-    v-model="userData"
-  />
+      :schema="schema"
+      v-model="userData"
+    />
 
-    <div class="output">
-      vModel Output:
-      <ul>
-        <li
-          v-for="(value, prop) in userData"
-          :key="prop"
-        >
-          {{ prop }}: {{ value }}
-        </li>
-      </ul>
-    </div>
+    <p>
+      v-model object: <br>
+      {{ userData }}
+    </p>
+
+    <p>Form Output:</p>
+    <OutputDisplay :data="userData" />
   </div>
 </template>
 
@@ -65,7 +61,9 @@ const SCHEMA = {
   }
 }
 
+import OutputDisplay from './OutputDisplay'
 export default {
+  components: { OutputDisplay },
   data () {
     return {
       userData: {}
@@ -101,10 +99,4 @@ export default {
   text-align: left
   margin: 0 auto 4rem
   line-height: 1.6
-
-.output
-  max-width: 35rem
-  margin: 0 auto 4rem
-  ul
-    list-style: none
 </style>

--- a/docs/.vuepress/components/Formception.vue
+++ b/docs/.vuepress/components/Formception.vue
@@ -1,0 +1,110 @@
+<template>
+  <div>
+    <SchemaForm
+    :schema="schema"
+    v-model="userData"
+  />
+
+    <div class="output">
+      vModel Output:
+      <ul>
+        <li
+          v-for="(value, prop) in userData"
+          :key="prop"
+        >
+          {{ prop }}: {{ value }}
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+const SCHEMA = {
+  firstName: {
+    component: 'FormText',
+    label: 'First Name',
+  },
+  lastName: {
+    component: 'FormText',
+    label: 'Last Name',
+  },
+  email: {
+    component: 'FormText',
+    label: 'Your email',
+    required: true,
+    config: {
+      type: 'email'
+    }
+  },
+  isVueFan: {
+    component: 'FormCheckbox',
+    label: 'Are you a Vue fan?'
+  },
+  work: {
+    component: 'SchemaForm',
+    schema: {
+      address: {
+        component: 'FormText',
+        label: 'Work address'
+      },
+      phone: {
+        component: 'FormText',
+        label: 'Work phone'
+      },
+      details: {
+        component: 'SchemaForm',
+        schema: {
+          position: {
+            component: 'FormText',
+            label: 'Work position'
+          }
+        }
+      }
+    }
+  }
+}
+
+export default {
+  data () {
+    return {
+      userData: {}
+    }
+  },
+  computed: {
+    schema () {
+      return this.userData.isVueFan
+        ? {
+            ...SCHEMA,
+            feedback: {
+              component: 'FormText',
+              label: 'Gimme some feedback'
+            }
+          }
+        : SCHEMA
+    }
+  },
+  methods: {
+    mergeChanges (changes) {
+      this.userData = {
+        ...this.userData,
+        ...changes
+      }
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+.steps
+  max-width: 35rem
+  text-align: left
+  margin: 0 auto 4rem
+  line-height: 1.6
+
+.output
+  max-width: 35rem
+  margin: 0 auto 4rem
+  ul
+    list-style: none
+</style>

--- a/docs/.vuepress/components/OutputDisplay.vue
+++ b/docs/.vuepress/components/OutputDisplay.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="output">
+      <ul>
+        <li
+          v-for="(value, prop) in data"
+          :key="prop"
+        >
+          <template v-if="typeof value !== 'object'">
+            {{ prop }}: {{ value }}
+          </template>
+
+          <template v-else>
+            <OutputDisplay :data="value" />
+          </template>
+        </li>
+      </ul>
+    </div>
+</template>
+
+<script>
+export default {
+  props: {
+    data: { type: Object, required: true }
+  }
+}
+</script>
+
+<style lang="stylus">
+.output
+  max-width: 35rem
+  ul
+    list-style: none
+    padding-left: 0
+</style>

--- a/docs/.vuepress/components/SimpleExample.vue
+++ b/docs/.vuepress/components/SimpleExample.vue
@@ -7,17 +7,22 @@
 </template>
 
 <script>
+import OutputDisplay from './OutputDisplay'
+import FormText from '../../../src/form-elements/FormText'
+import FormSelect from '../../../src/form-elements/FormSelect'
+import FormCheckbox from '../../../src/form-elements/FormCheckbox'
+
 const SCHEMA = {
   firstName: {
-    component: 'FormText',
+    component: FormText,
     label: 'First Name',
   },
   lastName: {
-    component: 'FormText',
+    component: FormText,
     label: 'Last Name',
   },
   email: {
-    component: 'FormText',
+    component: FormText,
     label: 'Your email',
     required: true,
     config: {
@@ -25,7 +30,7 @@ const SCHEMA = {
     }
   },
   isVueFan: {
-    component: 'FormCheckbox',
+    component: FormCheckbox,
     label: 'Are you a Vue fan?'
   }
 }
@@ -42,7 +47,7 @@ export default {
         ? {
             ...SCHEMA,
             feedback: {
-              component: 'FormText',
+              component: FormText,
               label: 'Gimme some feedback'
             }
           }

--- a/docs/.vuepress/components/WizardExample.vue
+++ b/docs/.vuepress/components/WizardExample.vue
@@ -25,20 +25,25 @@
 </template>
 
 <script>
+import OutputDisplay from './OutputDisplay'
+import FormText from '../../../src/form-elements/FormText'
+import FormSelect from '../../../src/form-elements/FormSelect'
+import FormCheckbox from '../../../src/form-elements/FormCheckbox'
+
 const SCHEMA = [
   {
     firstName: {
-      component: 'FormText',
+      component: FormText,
       label: 'First Name',
     },
     lastName: {
-      component: 'FormText',
+      component: FormText,
       label: 'Last Name',
     }
   },
   {
     email: {
-      component: 'FormText',
+      component: FormText,
       label: 'Your email',
       required: true,
       config: {
@@ -46,7 +51,7 @@ const SCHEMA = [
       }
     },
     favoriteThingAboutVue: {
-      component: 'FormSelect',
+      component: FormSelect,
       label: 'Favorite thing about Vue',
       required: true,
       options: [
@@ -58,11 +63,11 @@ const SCHEMA = [
   },
   {
     address: {
-      component: 'FormText',
+      component: FormText,
       label: 'Work address'
     },
     phone: {
-      component: 'FormText',
+      component: FormText,
       label: 'Work phone'
     },
   }

--- a/docs/.vuepress/components/WizardExample.vue
+++ b/docs/.vuepress/components/WizardExample.vue
@@ -1,0 +1,92 @@
+<template>
+  <div>
+    <p>Step: {{ step + 1 }}</p>
+
+    <SchemaWizard
+      :schema="schema"
+      :step="step"
+      v-model="userData"
+    >
+      <button
+        v-if="step < schema.length - 1"
+        @click="step++">Next</button>
+      <button
+        v-if="step > 0"
+        @click="step--">Back</button>
+    </SchemaWizard>
+
+    <p>Form Output:</p>
+    <OutputDisplay
+      v-for="(section, index) in userData"
+      :key="index"
+      :data="section"
+    />
+  </div>
+</template>
+
+<script>
+const SCHEMA = [
+  {
+    firstName: {
+      component: 'FormText',
+      label: 'First Name',
+    },
+    lastName: {
+      component: 'FormText',
+      label: 'Last Name',
+    }
+  },
+  {
+    email: {
+      component: 'FormText',
+      label: 'Your email',
+      required: true,
+      config: {
+        type: 'email'
+      }
+    },
+    favoriteThingAboutVue: {
+      component: 'FormSelect',
+      label: 'Favorite thing about Vue',
+      required: true,
+      options: [
+        'Ease of use',
+        'Documentation',
+        'Community'
+      ]
+    },
+  },
+  {
+    address: {
+      component: 'FormText',
+      label: 'Work address'
+    },
+    phone: {
+      component: 'FormText',
+      label: 'Work phone'
+    },
+  }
+]
+
+export default {
+  data() {
+    return {
+      userData: [],
+      step: 0
+    }
+  },
+  computed: {
+    schema() {
+      return SCHEMA
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+button
+  padding: 4px 8px
+  border-radius: 3px
+  border: 1px solid #ccc
+  font-size: 1rem
+</style>

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -1,7 +1,9 @@
 import SchemaForm from '../../src/SchemaForm.vue'
+import SchemaWizard from '../../src/SchemaWizard.vue'
 
 export default ({
   Vue
 }) => {
   Vue.component('SchemaForm', SchemaForm)
+  Vue.component('SchemaWizard', SchemaWizard)
 }

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,5 +1,8 @@
+*
+  box-sizing: border-box
+
 .schema-form
-  width: 250px
+  width: 350px
   margin: 0 auto
   text-align: left
 
@@ -18,3 +21,24 @@
 
   input[type="checkbox"]
     width: auto
+
+  select
+    width: 100%
+    margin-bottom: 1rem
+    border: 1px solid #ccc
+    border-radius: 3px
+    padding: 8px 10px
+    font-size: 1rem
+    -webkit-appearance: none
+    -moz-appearance: none
+    background-color: white
+    background-image: linear-gradient(45deg, transparent 50%, gray 50%),
+                      linear-gradient(135deg, gray 50%, transparent 50%),
+                      linear-gradient(to right, #ccc, #ccc)
+    background-position: calc(100% - 20px) calc(1em + 0px),
+                        calc(100% - 15px) calc(1em + 0px),
+                        calc(100% - 2.5em) 0.4em
+    background-size: 5px 5px,
+                    5px 5px,
+                    1px 1.5em
+    background-repeat: no-repeat

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,0 +1,20 @@
+.schema-form
+  width: 250px
+  margin: 0 auto
+  text-align: left
+
+  label
+    font-weight: bold
+    font-size: 0.9rem
+    display: block
+
+  input
+    padding: 8px 10px
+    border-radius: 3px
+    border: 1px solid #ccc
+    margin-bottom: 1rem
+    width: 100%
+    font-size: 1rem
+
+  input[type="checkbox"]
+    width: auto

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,6 +1,6 @@
 *
   box-sizing: border-box
-
+  
 .schema-form
   width: 350px
   margin: 0 auto

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,3 +19,7 @@ footer: MIT Licensed | Copyright © 2019-present Damian Dulisz
 ## V-Model Example
 
 <ExampleVModel></ExampleVModel>
+
+## Formception
+
+<Formception></Formception>

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,3 +15,7 @@ footer: MIT Licensed | Copyright © 2019-present Damian Dulisz
 ## Example
 
 <SimpleExample></SimpleExample>
+
+## V-Model Example
+
+<ExampleVModel></ExampleVModel>

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,3 +23,7 @@ footer: MIT Licensed | Copyright © 2019-present Damian Dulisz
 ## Formception
 
 <Formception></Formception>
+
+## Schema Wizard
+
+<WizardExample></WizardExample>

--- a/src/FormMixin.js
+++ b/src/FormMixin.js
@@ -1,10 +1,6 @@
 export default {
   props: {
     value: { required: true },
-    label: {
-      type: String,
-      required: true
-    },
     required: {
       type: Boolean,
       default: false

--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -31,12 +31,16 @@ export default {
       required: true
     }
   },
+  data () {
+    return {
+      values: {}
+    }
+  },
   methods: {
     update (property, value) {
-      this.$emit('input', {
-        ...this.values,
-        [property]: value
-      })
+      this.$set(this.values, property, value)
+
+      this.$emit('input', this.values)
     }
   }
 }

--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -45,26 +45,3 @@ export default {
   }
 }
 </script>
-
-<style lang="stylus">
-.schema-form
-  width: 250px
-  margin: 0 auto
-  text-align: left
-
-  label
-    font-weight: bold
-    font-size: 0.9rem
-    display: block
-
-  input
-    padding: 8px 10px
-    border-radius: 3px
-    border: 1px solid #ccc
-    margin-bottom: 1rem
-    width: 100%
-    font-size: 1rem
-
-  input[type="checkbox"]
-    width: auto
-</style>

--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -1,15 +1,19 @@
 <template>
-  <form class="schema-form">
-    <component
-      v-for="(field, property) in schema"
-      :key="property"
-      :is="field.component"
-      v-bind="binds(field)"
-      :value="val(property, field)"
-      @input="update(property, $event)"
-    />
-    <slot/>
-  </form>
+  <div>
+    <slot name="beforeForm"></slot>
+    <form class="schema-form">
+      <component
+        v-for="(field, property) in schema"
+        :key="property"
+        :is="field.component"
+        v-bind="binds(field)"
+        :value="val(property, field)"
+        @input="update(property, $event)"
+      />
+      <slot/>
+    </form>
+    <slot name="afterForm"></slot>
+  </div>
 </template>
 
 <script>

--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -17,16 +17,7 @@
 </template>
 
 <script>
-import FormCheckbox from './form-elements/FormCheckbox'
-import FormText from './form-elements/FormText'
-import FormSelect from './form-elements/FormSelect'
-
 export default {
-  components: {
-    FormCheckbox,
-    FormText,
-    FormSelect
-  },
   props: {
     schema: {
       type: Object,
@@ -49,12 +40,12 @@ export default {
       this.$emit('input', this.values)
     },
     binds (field) {
-      return field.component === 'SchemaForm'
+      return field.schema
         ? { schema: field.schema }
         : field
     },
     val (property, field) {
-      if (field.component === 'SchemaForm' && !this.values[property]) {
+      if (field.schema && !this.values[property]) {
         return {}
       }
 

--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -15,11 +15,13 @@
 <script>
 import FormCheckbox from './form-elements/FormCheckbox'
 import FormText from './form-elements/FormText'
+import FormSelect from './form-elements/FormSelect'
 
 export default {
   components: {
     FormCheckbox,
-    FormText
+    FormText,
+    FormSelect
   },
   props: {
     schema: {

--- a/src/SchemaForm.vue
+++ b/src/SchemaForm.vue
@@ -4,8 +4,8 @@
       v-for="(field, property) in schema"
       :key="property"
       :is="field.component"
-      v-bind="{ ...field }"
-      :value="value[property]"
+      v-bind="binds(field)"
+      :value="val(property, field)"
       @input="update(property, $event)"
     />
     <slot/>
@@ -41,6 +41,18 @@ export default {
       this.$set(this.values, property, value)
 
       this.$emit('input', this.values)
+    },
+    binds (field) {
+      return field.component === 'SchemaForm'
+        ? { schema: field.schema }
+        : field
+    },
+    val (property, field) {
+      if (field.component === 'SchemaForm' && !this.values[property]) {
+        return {}
+      }
+
+      return this.values[property]
     }
   }
 }

--- a/src/SchemaWizard.vue
+++ b/src/SchemaWizard.vue
@@ -1,0 +1,50 @@
+<template>
+  <div>
+    <SchemaForm
+      :schema="currentSchema"
+      :value="value[step] || {}"
+      @input="update"
+    />
+
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+import SchemaForm from './SchemaForm'
+export default {
+  components: { SchemaForm },
+  props: {
+    schema: {
+      type: Array,
+      required: true
+    },
+    step: {
+      type: Number,
+      required: true,
+      default: 0
+    },
+    value: {
+      type: Array,
+      required: true
+    }
+  },
+  data () {
+    return {
+      wizardValues: []
+    }
+  },
+  computed: {
+    currentSchema () {
+      return this.schema[this.step]
+    }
+  },
+  methods: {
+    update (data) {
+      this.$set(this.wizardValues, this.step, data)
+
+      this.$emit('input', this.wizardValues)
+    }
+  }
+}
+</script>

--- a/src/SchemaWizard.vue
+++ b/src/SchemaWizard.vue
@@ -29,11 +29,6 @@ export default {
       required: true
     }
   },
-  data () {
-    return {
-      wizardValues: []
-    }
-  },
   computed: {
     currentSchema () {
       return this.schema[this.step]
@@ -41,9 +36,10 @@ export default {
   },
   methods: {
     update (data) {
-      this.$set(this.wizardValues, this.step, data)
+      const value = [...this.value]
+      value[this.step] = data
 
-      this.$emit('input', this.wizardValues)
+      this.$emit('input', value)
     }
   }
 }

--- a/src/form-elements/FormCheckbox.vue
+++ b/src/form-elements/FormCheckbox.vue
@@ -14,5 +14,13 @@
 <script>
 import FormMixin from '../FormMixin'
 
-export default { mixins: [ FormMixin ] }
+export default {
+  mixins: [ FormMixin ],
+  props: {
+    label: {
+      type: String,
+      required: true
+    }
+  }
+}
 </script>

--- a/src/form-elements/FormSelect.vue
+++ b/src/form-elements/FormSelect.vue
@@ -1,0 +1,34 @@
+<template>
+  <div>
+    <label :for="label">
+      {{ label }}
+    </label>
+    <select
+      :value="value"
+      :required="required"
+      :id="label"
+      @input="update($event.target.value)"
+    >
+      <option
+        v-for="option in options"
+        :key="option"
+        :value="option"
+        :selected="option === value"
+      >
+        {{ option }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<script>
+import FormMixin from '../FormMixin'
+
+export default {
+  mixins: [FormMixin],
+  props: {
+    label: { type: String, required: true },
+    options: { type: Array, required: true }
+  }
+}
+</script>

--- a/src/form-elements/FormText.vue
+++ b/src/form-elements/FormText.vue
@@ -19,6 +19,10 @@ import FormMixin from '../FormMixin'
 export default {
   mixins: [ FormMixin ],
   props: {
+    label: {
+      type: String,
+      required: true
+    },
     config: {
       type: Object,
       default: () => ({ type: 'text' })


### PR DESCRIPTION
I think we should keep the FormMixin unopinionated, having a required label property is fine for the provided example but if users are going to be able to pull this mixin into their own components then we shouldn't assume that every input is going to have a required label property. Maybe they want to do that as a slot, or with some other configuration.

I've moved the prop to the example components and removed it from the mixin, but open for comments.